### PR TITLE
Removed unused function to create new context for variable.

### DIFF
--- a/operationsbus/operation_handler.go
+++ b/operationsbus/operation_handler.go
@@ -13,5 +13,4 @@ type APIOperation interface {
 	Init(context.Context, OperationRequest) (APIOperation, error)
 	GetName(context.Context) string
 	GetOperationRequest(context.Context) *OperationRequest
-	NewContextForOperation(context.Context) (context.Context, error)
 }


### PR DESCRIPTION
Removing unused operation NewContextForOperation, since we're no longer supporting expiration.