### PR TITLE
Added the entityController as default

### DIFF
--- a/operationsbus/entity_controller.go
+++ b/operationsbus/entity_controller.go
@@ -1,0 +1,9 @@
+package operationsbus
+
+import (
+	"context"
+)
+
+type EntityController interface {
+	GetEntity(context.Context, OperationRequest) (Entity, error)
+}

--- a/operationsbus/hooks_test.go
+++ b/operationsbus/hooks_test.go
@@ -36,11 +36,11 @@ type LongRunningOperation struct {
 	num   int
 }
 
-func (l *LongRunningOperation) Run(context.Context) error {
+func (l *LongRunningOperation) Run(ctx context.Context) error {
 	return nil
 }
 
-func (l *LongRunningOperation) GuardConcurrency(context.Context) *CategorizedError {
+func (l *LongRunningOperation) GuardConcurrency(ctx context.Context, entity Entity) *CategorizedError {
 	return nil
 }
 
@@ -93,7 +93,7 @@ func TestHooks(t *testing.T) {
 		t.Fatalf("Error initializing operation: " + err.Error())
 	}
 
-	_ = hOperation.GuardConcurrency(ctx)
+	_ = hOperation.GuardConcurrency(ctx, nil)
 	_ = hOperation.Run(ctx)
 	if longOp, ok := (*hOperation.Operation).(*LongRunningOperation); ok {
 		if longOp.num == 3 {
@@ -121,7 +121,7 @@ func TestHooks(t *testing.T) {
 		t.Fatalf("Error initializing operation: " + err.Error())
 	}
 
-	_ = hOperation.GuardConcurrency(ctx)
+	_ = hOperation.GuardConcurrency(ctx, nil)
 	_ = hOperation.Run(ctx)
 	if longOp, ok := (*hOperation.Operation).(*LongRunningOperation); ok {
 		if longOp.num == 3 {

--- a/operationsbus/matcher_test.go
+++ b/operationsbus/matcher_test.go
@@ -61,7 +61,7 @@ func (lr *LongRunning) InitOperation(ctx context.Context, req OperationRequest) 
 	return nil, nil
 }
 
-func (lr *LongRunning) GuardConcurrency(ctx context.Context) *CategorizedError {
+func (lr *LongRunning) GuardConcurrency(ctx context.Context, entity Entity) *CategorizedError {
 	fmt.Println("Guarding concurrency in LongRunning operation")
 	return &CategorizedError{}
 }

--- a/operationsbus/operation_handler.go
+++ b/operationsbus/operation_handler.go
@@ -7,7 +7,7 @@ import (
 // ApiOperation is the interface all operations will need to implement.
 type ApiOperation interface {
 	InitOperation(context.Context, OperationRequest) (ApiOperation, error)
-	GuardConcurrency(context.Context) *CategorizedError
+	GuardConcurrency(context.Context, Entity) *CategorizedError
 	Run(context.Context) error
 	GetOperationRequest() *OperationRequest
 }

--- a/operationsbus/processor.go
+++ b/operationsbus/processor.go
@@ -14,6 +14,7 @@ func CreateProcessor(
 	serviceBusReceiver sb.ReceiverInterface,
 	matcher *Matcher,
 	operationController OperationController,
+	entityController EntityController,
 	logger *slog.Logger,
 	customHandler shuttle.HandlerFunc,
 	processorOptions *shuttle.ProcessorOptions,
@@ -31,7 +32,7 @@ func CreateProcessor(
 	// Define the default handler chain
 	// Use the default handler if a custom handler is not provided
 	if customHandler == nil {
-		customHandler = DefaultHandlers(serviceBusReceiver, matcher, operationController, logger, hooks)
+		customHandler = DefaultHandlers(serviceBusReceiver, matcher, operationController, entityController, logger, hooks)
 	}
 
 	if processorOptions == nil {


### PR DESCRIPTION
EntityController will be used to grab the entity from whatever database you have your entities stored to be able to Guard against Concurrency. In case you don't wish to use this feature (since it's enforced by the default processOperation handler), you can simply implement it and set it to return a nil entity, and ignore the entity in the GuardConcurrency method of the respective operation.