### PR TITLE
Added entity matching inside the matcher.

### DIFF
--- a/operationsbus/matcher_test.go
+++ b/operationsbus/matcher_test.go
@@ -48,6 +48,90 @@ func TestMatcher(t *testing.T) {
 	}
 }
 
+func TestMatcher_RegisterAndGetEntity(t *testing.T) {
+	matcher := NewMatcher()
+
+	entityKey := "TestEntity"
+	lastOperationId := "1"
+	matcher.RegisterEntity(entityKey, func(latestOperationId string) Entity {
+		return &TestEntity{latestOperationId: latestOperationId}
+	})
+
+	// Check if the entity creator is registered correctly
+	if _, exists := matcher.EntityCreators[entityKey]; !exists {
+		t.Fatalf("Entity creator for key %s should exist in the matcher", entityKey)
+	}
+
+	// Create an instance of the entity using the registered creator
+	entityInstance := matcher.EntityCreators[entityKey]
+
+	var entity Entity
+	if f, ok := matcher.EntityCreators[entityKey]; ok {
+		entity = f(lastOperationId)
+	} else {
+		t.Fatalf("Expected entity instance of type *TestEntity. Instead got: %T", entityInstance)
+	}
+
+	if entity.(*TestEntity).latestOperationId != "1" {
+		t.Fatalf("Expected entity name to be %s. Instead got: %s", lastOperationId, entity.(*TestEntity).latestOperationId)
+	}
+}
+
+func TestMatcher_CreateEntityInstance(t *testing.T) {
+	matcher := NewMatcher()
+
+	entityKey := "TestEntity"
+	lastOperationId := "1"
+	matcher.RegisterEntity(entityKey, func(latestOperationId string) Entity {
+		return &TestEntity{latestOperationId: latestOperationId}
+	})
+
+	// Create an instance of the entity using the matcher method
+	entityInstance, err := matcher.CreateEntityInstance(entityKey, lastOperationId)
+	if err != nil {
+		t.Fatalf("Expected no error. Instead got: %v", err)
+	}
+	if entity, ok := entityInstance.(*TestEntity); !ok {
+		t.Fatalf("Expected entity instance of type *TestEntity. Instead got: %T", entityInstance)
+	} else {
+		if entity.latestOperationId != lastOperationId {
+			t.Fatalf("lastestOperationId of entity doesn't match what was used to create the instance: " + lastOperationId)
+		}
+	}
+	if _, ok := entityInstance.(*TestEntity); !ok {
+		t.Fatalf("Expected entity instance of type *TestEntity. Instead got: %T", entityInstance)
+	}
+
+	if v := entityInstance.GetLatestOperationID(); v != lastOperationId {
+		t.Fatalf("Expected latestOperationId of entity to match lastOperationId: " + lastOperationId)
+	}
+}
+
+func TestMatcher_CreateEntityInstance_NonExistentKey(t *testing.T) {
+	matcher := NewMatcher()
+
+	entityKey := "NonExistentEntity"
+	_, err := matcher.CreateEntityInstance(entityKey, "1")
+	if err == nil {
+		t.Fatalf("Should not return function of non-existing entity.")
+	}
+}
+
+// Example implementatin of entity.
+type TestEntity struct {
+	latestOperationId string
+}
+
+func (e *TestEntity) GetLatestOperationID() string {
+	return e.latestOperationId
+}
+
+func NewTestEntity(latestOperationId string) *TestEntity {
+	return &TestEntity{
+		latestOperationId: latestOperationId,
+	}
+}
+
 // Example implementation of ApiOperation for LongRunning
 type LongRunning struct {
 	num int


### PR DESCRIPTION
Improved entity matching. This PR doesn't break any previous functionality, but adds entity matching using the EntityFactoryFunc by allowing the user to provide a function to create their entity. Since the only thing they should need is a string, thats the only thing we allow for now for the entity.