### PR TITLE
Updated hooks.

### DIFF
--- a/operationsbus/hooks.go
+++ b/operationsbus/hooks.go
@@ -8,36 +8,36 @@ import (
 
 type BaseOperationHooksInterface interface {
 	BeforeInitOperation(ctx context.Context, req OperationRequest) error
-	AfterInitOperation(ctx context.Context, op *ApiOperation, req OperationRequest, err error) error
+	AfterInitOperation(ctx context.Context, op ApiOperation, req OperationRequest, err error) error
 
-	BeforeGuardConcurrency(ctx context.Context, op *ApiOperation, entity Entity) error
-	AfterGuardConcurrency(ctx context.Context, op *ApiOperation, ce *CategorizedError) error
+	BeforeGuardConcurrency(ctx context.Context, op ApiOperation, entity Entity) error
+	AfterGuardConcurrency(ctx context.Context, op ApiOperation, ce *CategorizedError) error
 
-	BeforeRun(ctx context.Context, op *ApiOperation) error
-	AfterRun(ctx context.Context, op *ApiOperation, err error) error
+	BeforeRun(ctx context.Context, op ApiOperation) error
+	AfterRun(ctx context.Context, op ApiOperation, err error) error
 }
 
 type HookedApiOperation struct {
-	Operation      *ApiOperation
+	Operation      ApiOperation
 	OperationHooks []BaseOperationHooksInterface
 }
 
 func (h *HookedApiOperation) BeforeInitOperation(ctx context.Context, req OperationRequest) error {
 	return nil
 }
-func (h *HookedApiOperation) AfterInitOperation(ctx context.Context, op *ApiOperation, req OperationRequest, err error) error {
+func (h *HookedApiOperation) AfterInitOperation(ctx context.Context, op ApiOperation, req OperationRequest, err error) error {
 	return nil
 }
-func (h *HookedApiOperation) BeforeGuardConcurrency(ctx context.Context, op *ApiOperation, entity Entity) error {
+func (h *HookedApiOperation) BeforeGuardConcurrency(ctx context.Context, op ApiOperation, entity Entity) error {
 	return nil
 }
-func (h *HookedApiOperation) AfterGuardConcurrency(ctx context.Context, op *ApiOperation, ce *CategorizedError) error {
+func (h *HookedApiOperation) AfterGuardConcurrency(ctx context.Context, op ApiOperation, ce *CategorizedError) error {
 	return nil
 }
-func (h *HookedApiOperation) BeforeRun(ctx context.Context, op *ApiOperation) error {
+func (h *HookedApiOperation) BeforeRun(ctx context.Context, op ApiOperation) error {
 	return nil
 }
-func (h *HookedApiOperation) AfterRun(ctx context.Context, op *ApiOperation, err error) error {
+func (h *HookedApiOperation) AfterRun(ctx context.Context, op ApiOperation, err error) error {
 	return nil
 }
 
@@ -54,7 +54,7 @@ func (h *HookedApiOperation) InitOperation(ctx context.Context, opReq OperationR
 	}
 
 	logger.Info("Running operation init.")
-	operation, err := (*h.Operation).InitOperation(ctx, opReq)
+	operation, err := h.Operation.InitOperation(ctx, opReq)
 
 	logger.Info("Running AfterInit hooks.")
 	for _, hook := range h.OperationHooks {
@@ -84,7 +84,7 @@ func (h *HookedApiOperation) GuardConcurrency(ctx context.Context, entity Entity
 	}
 
 	logger.Info("Running operation guard concurrency.")
-	ce := (*h.Operation).GuardConcurrency(ctx, entity)
+	ce := h.Operation.GuardConcurrency(ctx, entity)
 
 	logger.Info("Running AfterGuardConcurrency hooks.")
 	for _, hook := range h.OperationHooks {
@@ -114,7 +114,7 @@ func (h *HookedApiOperation) Run(ctx context.Context) error {
 	}
 
 	logger.Info("Running operation run.")
-	err := (*h.Operation).Run(ctx)
+	err := h.Operation.Run(ctx)
 
 	logger.Info("Running AfterRun hooks.")
 	for _, hook := range h.OperationHooks {

--- a/operationsbus/hooks_test.go
+++ b/operationsbus/hooks_test.go
@@ -12,17 +12,17 @@ type RunOnlyHooks struct {
 	HookedApiOperation
 }
 
-func (h *RunOnlyHooks) BeforeRun(ctx context.Context, op *ApiOperation) error {
+func (h *RunOnlyHooks) BeforeRun(ctx context.Context, op ApiOperation) error {
 	fmt.Println("This is the before internal run hook!")
-	if longOp, ok := (*op).(*LongRunningOperation); ok {
+	if longOp, ok := (op).(*LongRunningOperation); ok {
 		longOp.num += 1
 	}
 	return nil
 }
 
-func (h *RunOnlyHooks) AfterRun(ctx context.Context, op *ApiOperation, err error) error {
+func (h *RunOnlyHooks) AfterRun(ctx context.Context, op ApiOperation, err error) error {
 	fmt.Println("This is the after internal run hook!")
-	if longOp, ok := (*op).(*LongRunningOperation); ok {
+	if longOp, ok := (op).(*LongRunningOperation); ok {
 		longOp.num += 1
 	}
 	return nil
@@ -84,7 +84,7 @@ func TestHooks(t *testing.T) {
 	runOnlyHooks := &RunOnlyHooks{}
 	hooksSlice := []BaseOperationHooksInterface{runOnlyHooks}
 	hOperation := &HookedApiOperation{
-		Operation:      &operation,
+		Operation:      operation,
 		OperationHooks: hooksSlice,
 	}
 
@@ -95,7 +95,7 @@ func TestHooks(t *testing.T) {
 
 	_ = hOperation.GuardConcurrency(ctx, nil)
 	_ = hOperation.Run(ctx)
-	if longOp, ok := (*hOperation.Operation).(*LongRunningOperation); ok {
+	if longOp, ok := (hOperation.Operation).(*LongRunningOperation); ok {
 		if longOp.num == 3 {
 			t.Log("Hooks did ran successfully.")
 		} else {
@@ -123,7 +123,7 @@ func TestHooks(t *testing.T) {
 
 	_ = hOperation.GuardConcurrency(ctx, nil)
 	_ = hOperation.Run(ctx)
-	if longOp, ok := (*hOperation.Operation).(*LongRunningOperation); ok {
+	if longOp, ok := (hOperation.Operation).(*LongRunningOperation); ok {
 		if longOp.num == 3 {
 			t.Log("Hooks did ran successfully.")
 		} else {

--- a/operationsbus/matcher.go
+++ b/operationsbus/matcher.go
@@ -80,7 +80,7 @@ func (m *Matcher) CreateHookedInstace(key string, hooks []BaseOperationHooksInte
 	}
 
 	hOperation := &HookedApiOperation{
-		Operation:      &operation,
+		Operation:      operation,
 		OperationHooks: hooks,
 	}
 


### PR DESCRIPTION
Changed hooks to use ApiOperation instead of *ApiOperation since ApiOperation is an interface and doesn't need a pointer.